### PR TITLE
Remove use of callbacks in registerNewTask

### DIFF
--- a/imports/api/tasks.js
+++ b/imports/api/tasks.js
@@ -170,7 +170,7 @@ function checkForEditPermissions(user, task) {
 Meteor.methods({
     // TODO:  Data validation!
     // TODO:  _Definitely_ make task DB management a different API/class than userTask management.
-    'tasks.registerNewTask'(task, taskDetail){
+    'tasks.registerNewTask'(task, taskDetail) {
         // TODO:  If constructor-based matching after Meteor.call starts working in future versions of meteor, use that instead.
         validateTask(task);
         validateTaskDetailOfType(task.task_type, taskDetail);
@@ -184,32 +184,20 @@ Meteor.methods({
         // TODO:  Make this work for task types other than phone!
         // TODO:  Take out all manual references to phone task strings!
         task.owner = Meteor.userId();
-        Tasks.insert(task, function(err, taskId) {
-            if (err) { console.log(err); }
-            else {
-                taskDetail.parent_task_id = taskId._str;
-                switch(task.task_type) {
-                    case PBTaskTypesEnum.phone:
-                        PhoneTasks.insert(taskDetail, function(err, taskDetailId) {
-                            if (err) { console.log(err) }
-                            else {
-                                Tasks.update(taskId, {$set : {task_detail_id : taskDetailId._str}})
-                            }
-                        });
-                        break;
-                    case PBTaskTypesEnum.freeform:
-                        FreeformTasks.insert(taskDetail, function(err, taskDetailId) {
-                            if (err) { console.log(err) }
-                            else {
-                                Tasks.update(taskId, {$set : {task_detail_id : taskDetailId._str}})
-                            }
-                        });
-                        break;
-                    default:
-                        throw new Meteor.Error("invalid-parameter", "The given task detail does not match the specified task type") // TODO:  figure out how check_fail works.
-                }
-            }
-        })
+        var taskId = Tasks.insert(task);
+        taskDetail.parent_task_id = taskId._str;
+        switch(task.task_type) {
+            case PBTaskTypesEnum.phone:
+                var taskDetailId = PhoneTasks.insert(taskDetail);
+                Tasks.update(taskId, {$set : {task_detail_id : taskDetailId._str}})
+                break;
+            case PBTaskTypesEnum.freeform:
+                var taskDetailId = FreeformTasks.insert(taskDetail)
+                Tasks.update(taskId, {$set : {task_detail_id : taskDetailId._str}})
+                break;
+            default:
+                throw new Meteor.Error("invalid-parameter", "The given task detail does not match the specified task type") // TODO:  figure out how check_fail works.
+        }
     },
 
     // Stops a task from being given to any additional users.


### PR DESCRIPTION
Passing a callback to collection insert makes it asynchronous, thus in many cases registerNewTask was returning before the new tasks were fully inserted. Not having a callback also makes error handling better by throwing instead of swallowing the error as currently was happening.

All tests should consistently pass now, should be safe to turn on CircleCI and start paying attention to the results.